### PR TITLE
Deprecate extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][unreleased]
 
+## [1.1.0] - 2020-04-04
+
+### Changed
+
+ - Modified output to match the GFM spec
+
+### Deprecated
+
+**This extension has been deprecated**.  All of its functionality now exists in league/commonmark 1.3+ under the `League\CommonMark\Extension\TaskList` namespace.
+
 ## [1.0.1] - 2019-07-10
 
 ### Changed
@@ -28,7 +38,8 @@ No code changes have been introduced since 1.0.0-beta1.
 
 Initial release!
 
-[unreleased]: https://github.com/thephpleague/commonmark-ext-task-list/compare/v1.0.1...HEAD
+[unreleased]: https://github.com/thephpleague/commonmark-ext-task-list/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/thephpleague/commonmark-ext-task-list/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/thephpleague/commonmark-ext-task-list/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/thephpleague/commonmark-ext-task-list/compare/v1.0.0-beta1...v1.0.0
 [1.0.0-beta1]: https://github.com/thephpleague/commonmark-ext-task-list/compare/v0.1.0...v1.0.0-beta1

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 [![Quality Score][ico-code-quality]][link-code-quality]
 [![Total Downloads][ico-downloads]][link-downloads]
 
+## DEPRECATED
+
+**This extension has been deprecated**.  All of its functionality now exists in [`league/commonmark`][link-league-commonmark] 1.3+ under the `League\CommonMark\Extension\TaskList` namespace, so you should upgrade to that version and use that bundled extension instead of this one.
+
+## Overview
+
 This extension adds [GFM-style task list items][link-gfm-spec-task-lists] to the [`league/commonmark` Markdown parser for PHP][link-league-commonmark].
 
 ## Install

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php" : "^7.1",
-        "league/commonmark": "^0.19|^1.0"
+        "league/commonmark": "^1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5"
@@ -35,7 +35,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1-dev"
+            "dev-master": "1.2-dev"
         }
-    }
+    },
+    "abandoned": "league/commonmark"
 }

--- a/src/TaskListExtension.php
+++ b/src/TaskListExtension.php
@@ -13,12 +13,23 @@ namespace League\CommonMark\Ext\TaskList;
 
 use League\CommonMark\ConfigurableEnvironmentInterface;
 use League\CommonMark\Extension\ExtensionInterface;
+use League\CommonMark\Extension\TaskList\TaskListExtension as CoreExtension;
 
+/**
+ * @deprecated The league/commonmark-ext-task-list extension is now deprecated. All functionality has been moved into league/commonmark 1.3+, so use that instead.
+ */
 final class TaskListExtension implements ExtensionInterface
 {
+    private $coreExtension;
+
+    public function __construct()
+    {
+        @trigger_error(sprintf('league/commonmark-ext-task-list is deprecated; use %s from league/commonmark 1.3+ instead', CoreExtension::class), E_USER_DEPRECATED);
+        $this->coreExtension = new CoreExtension();
+    }
+
     public function register(ConfigurableEnvironmentInterface $environment)
     {
-        $environment->addInlineParser(new TaskListItemMarkerParser(), 35);
-        $environment->addInlineRenderer(TaskListItemMarker::class, new TaskListItemMarkerRenderer());
+        $this->coreExtension->register($environment);
     }
 }

--- a/src/TaskListItemMarker.php
+++ b/src/TaskListItemMarker.php
@@ -13,24 +13,32 @@ namespace League\CommonMark\Ext\TaskList;
 
 use League\CommonMark\Inline\Element\AbstractInline;
 
-final class TaskListItemMarker extends AbstractInline
-{
-    protected $checked = false;
+@trigger_error('league/commonmark-ext-task-list is deprecated; use League\CommonMark\Extension\TaskList\TaskListItemMarker from league/commonmark 1.3+ instead', E_USER_DEPRECATED);
+class_alias('League\CommonMark\Extension\TaskList\TaskListItemMarker', 'League\CommonMark\Ext\TaskList\TaskListItemMarker');
 
-    public function __construct(bool $isCompleted)
+if (false) {
+    /**
+     * @deprecated The league/commonmark-ext-task-list extension is now deprecated. All functionality has been moved into league/commonmark 1.3+, so use that instead.
+     */
+    final class TaskListItemMarker extends AbstractInline
     {
-        $this->checked = $isCompleted;
-    }
+        protected $checked = false;
 
-    public function isChecked(): bool
-    {
-        return $this->checked;
-    }
+        public function __construct(bool $isCompleted)
+        {
+            $this->checked = $isCompleted;
+        }
 
-    public function setChecked(bool $checked): self
-    {
-        $this->checked = $checked;
+        public function isChecked(): bool
+        {
+            return $this->checked;
+        }
 
-        return $this;
+        public function setChecked(bool $checked): self
+        {
+            $this->checked = $checked;
+
+            return $this;
+        }
     }
 }

--- a/src/TaskListItemMarkerParser.php
+++ b/src/TaskListItemMarkerParser.php
@@ -11,19 +11,29 @@
 
 namespace League\CommonMark\Ext\TaskList;
 
-use League\CommonMark\Block\Element\ListItem;
-use League\CommonMark\Block\Element\Paragraph;
+use League\CommonMark\Extension\TaskList\TaskListItemMarkerParser as CoreParser;
 use League\CommonMark\Inline\Parser\InlineParserInterface;
 use League\CommonMark\InlineParserContext;
 
+/**
+ * @deprecated The league/commonmark-ext-task-list extension is now deprecated. All functionality has been moved into league/commonmark 1.3+, so use that instead.
+ */
 final class TaskListItemMarkerParser implements InlineParserInterface
 {
+    private $coreParser;
+
+    public function __construct()
+    {
+        @trigger_error(sprintf('league/commonmark-ext-task-list is deprecated; use %s from league/commonmark 1.3+ instead', CoreParser::class), E_USER_DEPRECATED);
+        $this->coreParser = new CoreParser();
+    }
+
     /**
      * @return string[]
      */
     public function getCharacters(): array
     {
-        return ['['];
+        return $this->coreParser->getCharacters();
     }
 
     /**
@@ -33,31 +43,6 @@ final class TaskListItemMarkerParser implements InlineParserInterface
      */
     public function parse(InlineParserContext $inlineContext): bool
     {
-        $container = $inlineContext->getContainer();
-
-        // Checkbox must come at the beginning of the first paragraph of the list item
-        if ($container->hasChildren() || !($container instanceof Paragraph && $container->parent() && $container->parent() instanceof ListItem)) {
-            return false;
-        }
-
-        $cursor = $inlineContext->getCursor();
-        $oldState = $cursor->saveState();
-
-        $m = $cursor->match('/\[[ xX]\]/');
-        if ($m === null) {
-            return false;
-        }
-
-        if ($cursor->getNextNonSpaceCharacter() === null) {
-            $cursor->restoreState($oldState);
-
-            return false;
-        }
-
-        $isChecked = $m !== '[ ]';
-
-        $container->appendChild(new TaskListItemMarker($isChecked));
-
-        return true;
+        return $this->coreParser->parse($inlineContext);
     }
 }

--- a/src/TaskListItemMarkerRenderer.php
+++ b/src/TaskListItemMarkerRenderer.php
@@ -12,12 +12,24 @@
 namespace League\CommonMark\Ext\TaskList;
 
 use League\CommonMark\ElementRendererInterface;
+use League\CommonMark\Extension\TaskList\TaskListItemMarkerRenderer as CoreRenderer;
 use League\CommonMark\HtmlElement;
 use League\CommonMark\Inline\Element\AbstractInline;
 use League\CommonMark\Inline\Renderer\InlineRendererInterface;
 
+/**
+ * @deprecated The league/commonmark-ext-task-list extension is now deprecated. All functionality has been moved into league/commonmark 1.3+, so use that instead.
+ */
 final class TaskListItemMarkerRenderer implements InlineRendererInterface
 {
+    private $coreRenderer;
+
+    public function __construct()
+    {
+        @trigger_error(sprintf('league/commonmark-ext-task-list is deprecated; use %s from league/commonmark 1.3+ instead', CoreRenderer::class), E_USER_DEPRECATED);
+        $this->coreRenderer = new CoreRenderer();
+    }
+
     /**
      * @param AbstractInline           $inline
      * @param ElementRendererInterface $htmlRenderer
@@ -26,16 +38,6 @@ final class TaskListItemMarkerRenderer implements InlineRendererInterface
      */
     public function render(AbstractInline $inline, ElementRendererInterface $htmlRenderer)
     {
-        if (!($inline instanceof TaskListItemMarker)) {
-            throw new \InvalidArgumentException('Incompatible inline type: ' . \get_class($inline));
-        }
-
-        $checkbox = new HtmlElement('input', ['disabled' => '', 'type' => 'checkbox'], '', true);
-
-        if ($inline->isChecked()) {
-            $checkbox->setAttribute('checked', '');
-        }
-
-        return $checkbox;
+        return $this->coreRenderer->render($inline, $htmlRenderer);
     }
 }

--- a/tests/TaskListExtensionTest.php
+++ b/tests/TaskListExtensionTest.php
@@ -60,34 +60,24 @@ EOT;
 
         $expected = <<<'EOT'
 <ul>
-<li>
-<input disabled="" type="checkbox" checked="" /> foo
+<li><input checked="" disabled="" type="checkbox"> foo
 <ul>
-<li>
-<input disabled="" type="checkbox" /> bar</li>
-<li>
-<input disabled="" type="checkbox" checked="" /> baz</li>
+<li><input disabled="" type="checkbox"> bar</li>
+<li><input checked="" disabled="" type="checkbox"> baz</li>
 </ul>
 </li>
-<li>
-<input disabled="" type="checkbox" /> bim</li>
+<li><input disabled="" type="checkbox"> bim</li>
 </ul>
 <ul>
-<li>
-<input disabled="" type="checkbox" checked="" /> foo</li>
-<li>
-<input disabled="" type="checkbox" checked="" /> bar</li>
-<li>
-<input disabled="" type="checkbox" /> baz</li>
+<li><input checked="" disabled="" type="checkbox"> foo</li>
+<li><input checked="" disabled="" type="checkbox"> bar</li>
+<li><input disabled="" type="checkbox"> baz</li>
 </ul>
 <p>This works for ordered lists too:</p>
 <ol>
-<li>
-<input disabled="" type="checkbox" checked="" /> foo</li>
-<li>
-<input disabled="" type="checkbox" checked="" /> bar</li>
-<li>
-<input disabled="" type="checkbox" /> baz</li>
+<li><input checked="" disabled="" type="checkbox"> foo</li>
+<li><input checked="" disabled="" type="checkbox"> bar</li>
+<li><input disabled="" type="checkbox"> baz</li>
 </ol>
 <p>Some examples which should not match:</p>
 <ul>
@@ -111,8 +101,7 @@ EOT;
 </ul>
 <p>Here's a test using <code>&lt;del&gt;</code>:</p>
 <ul>
-<li>
-<input disabled="" type="checkbox" checked="" /> <del>Checkbox inside of strikeout</del>
+<li><input checked="" disabled="" type="checkbox"> <del>Checkbox inside of strikeout</del>
 </li>
 </ul>
 <p>And another which does not render the checkbox:</p>


### PR DESCRIPTION
The league/commonmark-ext-task-list extension is being deprecated. All functionality has been moved into league/commonmark 1.3+, so use that instead.